### PR TITLE
По фиксу таймера

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -112,9 +112,6 @@ def is_valid_order(order):
     if any(word in order["time_info"] for word in CONFIG["FILTERS"]["TIME_KEYWORDS"]):
         return False
 
-    # Фильтр по времени публикации
-    if order["time_info"] == '1 минуту назад':
-        return False
 
     # Фильтр по ключевым словам
     if any(bad_word.lower() in order["subject"].lower() for bad_word in CONFIG["FILTERS"]["BAD_WORDS"]):


### PR DESCRIPTION
У профи очень плохая система защиты от бот-заказов, из-за того что время от времени парсер ловит заказы созданные минуту назад, если на такие заказы заходить, то скорее всего они будут (Закрыты или удалены). Поэтому лучше оставлять эту фильтрацию, так есть шанс что парсить мы будем реальные заказы, а не спам 